### PR TITLE
Replace Flattr with GitHub Sponsors

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
                 <li><a href="https://github.com/mucommander/mucommander/wiki/FAQ">FAQ</a></li>
                 <li><a href="https://github.com/mucommander/mucommander/issues">Report issues</a></li>
                 <li><a href="https://github.com/mucommander/mucommander/wiki/Translation">Translate</a></li>
-                <li><a href="https://github.com/mucommander/mucommander/wiki/Donate">Donate</a></li>
+                <li><a href="https://github.com/sponsors/mucommander">Sponsor</a></li>
                 <li><a href="https://github.com/mucommander/mucommander/wiki">Documentation</a></li>
                 <li><a href="https://twitter.com/mucommander">Twitter</a></li>
                 <li><a href="https://github.com/mucommander/mucommander#mucommander">GitHub</a></li>


### PR DESCRIPTION
Flattr's micro-donation service that is being shut down is replaced with GitHub Sponsors - updating the main webpage.